### PR TITLE
Only require express if an app is being used.

### DIFF
--- a/lib/express-helpers.js
+++ b/lib/express-helpers.js
@@ -1,6 +1,8 @@
-var express = require('express');
 module.exports = function(app) {
 	var helpers = {};
+	if (app) {
+		var express = require('express');
+	}
 	
 	helpers.HTML5 = "html5";
 	helpers.HTML4s = "html4s";


### PR DESCRIPTION
If we're using only the helpers, and we don't pass an app, then we shouldn't need to require express. That should allow these helpers to be used without Express.
