### PR TITLE
Made function check case insensitive

### DIFF
--- a/lib/express-helpers.js
+++ b/lib/express-helpers.js
@@ -624,7 +624,7 @@ module.exports = function(app) {
 		Null:function(a){return a===null;},
 		Undefined:function(a){return a===undefined;},
 		nt:function(a){return(a===null||a===undefined);},
-		Function:function(a){return(typeof(a)==='function')?a.constructor.toString().match(/Function/)!==null:false;},
+		Function:function(a){return(typeof(a)==='function')?a.constructor.toString().match(/Function/i)!==null:false;},
 		String:function(a){return(typeof(a)==='string')?true:(typeof(a)==='object')?a.constructor.toString().match(/string/i)!==null:false;		},
 		Array:function(a){return(typeof(a)==='object')?a.constructor.toString().match(/array/i)!==null||a.length!==undefined:false;},
 		Boolean:function(a){return(typeof(a)==='boolean')?true:(typeof(a)==='object')?a.constructor.toString().match(/boolean/i)!==null:false;},


### PR DESCRIPTION
`Test.js` fails with the latest version (4.12.1) of express package:

```
/Users/mikalai/GitHub/express-helpers/lib/express-helpers.js:673
s.Server && app instanceof express.Server) || app instanceof express.HTTPServe
                                                                    ^
TypeError: Expecting a function in instanceof check, but got undefined
    at module.exports (/Users/mikalai/GitHub/express-helpers/lib/express-helpers.js:673:87)
    at Object.<anonymous> (/Users/mikalai/GitHub/express-helpers/test/test.js:6:48)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
    at startup (node.js:129:16)
    at node.js:814:3
```

The thing is that [`type.of(app)` at line 649](https://github.com/tanema/express-helpers/blob/master/lib/express-helpers.js#L649) returns `undefined`.

The change is about fixing `is()` function to do case insensitive check for `function` string.

@tanema please review.
